### PR TITLE
Enhance the k8s-keystone to support whitelist for some resources

### DIFF
--- a/pkg/identity/keystone/authorizer_test.go
+++ b/pkg/identity/keystone/authorizer_test.go
@@ -281,6 +281,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
 			Roles:       {"developer"},
+			DomainName:  {"Default"},
 		},
 	}
 	viewer := &user.DefaultInfo{
@@ -290,6 +291,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 			ProjectName: {"demo"},
 			ProjectID:   {"ff9db8980cf24a74bc9dd796b6ce811f"},
 			Roles:       {"viewer"},
+			DomainName:  {"Default"},
 		},
 	}
 	anotherviewer := &user.DefaultInfo{
@@ -299,6 +301,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 			ProjectName: {"alt_demo"},
 			ProjectID:   {"cd08a539b7c845ddb92c5d08752101d1"},
 			Roles:       {"viewer"},
+			DomainName:  {"Default"},
 		},
 	}
 	clusteradmin := &user.DefaultInfo{
@@ -307,6 +310,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
 			Roles:       {"clusteradmin"},
+			DomainName:  {"Default"},
 		},
 	}
 

--- a/pkg/identity/keystone/authorizer_test_policy_version2.json
+++ b/pkg/identity/keystone/authorizer_test_policy_version2.json
@@ -2,30 +2,33 @@
   {
     "users": {
       "roles": ["developer"],
-      "projects": ["demo"]
+      "projects": ["demo"],
+      "domains": ["Default"]
     },
-    "resource_permissions": {
-      "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["*"],
-      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["get", "list"]
-    }
+    "resource_permissions": [
+      {"!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']/['*']": ["*"]},
+      {"!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']/['*']": ["get", "list"]}
+    ]
   },
   {
     "users": {
       "roles": ["viewer"],
-      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"]
+      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"],
+      "domains": ["Default"]
     },
-    "resource_permissions": {
-      "default/['*']": ["get", "list"]
-    }
+    "resource_permissions": [
+      {"default/['*']/['*']": ["get", "list"]}
+    ]
   },
   {
     "users": {
       "roles": ["clusteradmin"],
-      "projects": ["demo"]
+      "projects": ["demo"],
+      "domains": ["Default"]
     },
-    "resource_permissions": {
-      "*/*": ["*"]
-    },
+    "resource_permissions": [
+      {"*/*/*": ["*"]}
+    ],
     "nonresource_permissions": {
       "/healthz": ["get", "post"]
     }

--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -570,7 +570,7 @@ func createKubernetesClient(kubeConfig string) (*kubernetes.Clientset, error) {
 func createKeystoneClient(authURL string, caFile string) (*gophercloud.ServiceClient, error) {
 	// FIXME: Enable this check later
 	//if !strings.HasPrefix(authURL, "https") {
-	//	return nil, errors.New("Auth URL should be secure and start with https")
+	//      return nil, errors.New("Auth URL should be secure and start with https")
 	//}
 	var transport http.RoundTripper
 	if authURL == "" {

--- a/pkg/identity/keystone/policy.go
+++ b/pkg/identity/keystone/policy.go
@@ -29,7 +29,7 @@ type policy struct {
 
 	Match []policyMatch `json:"match"`
 
-	ResourcePermissionsSpec map[string][]string `json:"resource_permissions,omitempty"`
+	ResourcePermissionsSpec []map[string][]string `json:"resource_permissions,omitempty"`
 
 	NonResourcePermissionsSpec map[string][]string `json:"nonresource_permissions,omitempty"`
 


### PR DESCRIPTION
This patch includes two feature.
1. domain support in users rule. Different domains with same project name
and role will has different policy after this change.

2. to resourcesPermissions section, it is ordered right now.
In the front of the policy rule will have higher privilege to determine
the request permission.


